### PR TITLE
Add ability to order tracks by date added to playlist 

### DIFF
--- a/src/main/java/tech/makers/aceplay/playlist/Playlist.java
+++ b/src/main/java/tech/makers/aceplay/playlist/Playlist.java
@@ -3,12 +3,9 @@ package tech.makers.aceplay.playlist;
 import com.fasterxml.jackson.annotation.JsonGetter;
 
 import tech.makers.aceplay.playlisttracks.PlaylistTracks;
-import tech.makers.aceplay.track.Track;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
 
 import javax.persistence.*;
 

--- a/src/main/java/tech/makers/aceplay/playlist/Playlist.java
+++ b/src/main/java/tech/makers/aceplay/playlist/Playlist.java
@@ -5,8 +5,12 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import tech.makers.aceplay.playlisttracks.PlaylistTracks;
 import tech.makers.aceplay.track.Track;
 
-import javax.persistence.*;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
+
+import javax.persistence.*;
 
 // https://www.youtube.com/watch?v=vreyOZxdb5Y&t=448s
 @Entity
@@ -18,7 +22,8 @@ public class Playlist {
   private String name;
 
   @OneToMany(mappedBy = "playlist")
-  private Set<PlaylistTracks> tracks;
+  @OrderBy(value = "dateAdded")
+  private List<PlaylistTracks> tracks;
 
   public Playlist() {}
 
@@ -26,7 +31,7 @@ public class Playlist {
     this(name, null);
   }
 
-  public Playlist(String name, Set<PlaylistTracks> tracks) {
+  public Playlist(String name, List<PlaylistTracks> tracks) {
     this.name = name;
     this.tracks = tracks;
   }
@@ -44,9 +49,9 @@ public class Playlist {
   }
 
   @JsonGetter("tracks")
-  public Set<PlaylistTracks> getTracks() {
+  public List<PlaylistTracks> getTracks() {
     if (null == tracks) {
-      return Set.of();
+      return Collections.<PlaylistTracks>emptyList();
     }
     return tracks;
   }

--- a/src/main/java/tech/makers/aceplay/playlist/Playlist.java
+++ b/src/main/java/tech/makers/aceplay/playlist/Playlist.java
@@ -1,6 +1,8 @@
 package tech.makers.aceplay.playlist;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+
+import tech.makers.aceplay.playlisttracks.PlaylistTracks;
 import tech.makers.aceplay.track.Track;
 
 import javax.persistence.*;
@@ -15,8 +17,8 @@ public class Playlist {
 
   private String name;
 
-  @ManyToMany(fetch = FetchType.EAGER)
-  private Set<Track> tracks;
+  @OneToMany(mappedBy = "playlist")
+  private Set<PlaylistTracks> tracks;
 
   public Playlist() {}
 
@@ -24,7 +26,7 @@ public class Playlist {
     this(name, null);
   }
 
-  public Playlist(String name, Set<Track> tracks) {
+  public Playlist(String name, Set<PlaylistTracks> tracks) {
     this.name = name;
     this.tracks = tracks;
   }
@@ -42,7 +44,7 @@ public class Playlist {
   }
 
   @JsonGetter("tracks")
-  public Set<Track> getTracks() {
+  public Set<PlaylistTracks> getTracks() {
     if (null == tracks) {
       return Set.of();
     }

--- a/src/main/java/tech/makers/aceplay/playlist/PlaylistsController.java
+++ b/src/main/java/tech/makers/aceplay/playlist/PlaylistsController.java
@@ -3,6 +3,9 @@ package tech.makers.aceplay.playlist;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+
+import tech.makers.aceplay.playlisttracks.PlaylistTracks;
+import tech.makers.aceplay.playlisttracks.PlaylistTracksRepository;
 import tech.makers.aceplay.track.Track;
 import tech.makers.aceplay.track.TrackRepository;
 
@@ -14,6 +17,8 @@ public class PlaylistsController {
   @Autowired private PlaylistRepository playlistRepository;
 
   @Autowired private TrackRepository trackRepository;
+
+  @Autowired private PlaylistTracksRepository playlistTracksRepository;
 
   @GetMapping("/api/playlists")
   public Iterable<Playlist> playlists() {
@@ -32,13 +37,13 @@ public class PlaylistsController {
   }
 
   @PutMapping("/api/playlists/{id}/tracks")
-  public Track addTrack(@PathVariable Long id, @RequestBody TrackIdentifierDto trackIdentifierDto) {
+  public PlaylistTracks addTrack(@PathVariable Long id, @RequestBody TrackIdentifierDto trackIdentifierDto) {
     Playlist playlist = playlistRepository.findById(id)
             .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "No playlist exists with id " + id));
     Track track = trackRepository.findById(trackIdentifierDto.getId())
             .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "No track exists with id " + trackIdentifierDto.getId()));
-    playlist.getTracks().add(track);
-    playlistRepository.save(playlist);
-    return track;
+    PlaylistTracks playlistTracks = new PlaylistTracks(playlist, track);
+
+    return playlistTracksRepository.save(playlistTracks);
   }
 }

--- a/src/main/java/tech/makers/aceplay/playlisttracks/PlaylistTracks.java
+++ b/src/main/java/tech/makers/aceplay/playlisttracks/PlaylistTracks.java
@@ -1,5 +1,6 @@
 package tech.makers.aceplay.playlisttracks;
 
+import java.io.Serializable;
 import java.time.Clock;
 import java.time.LocalDateTime;
 
@@ -15,7 +16,7 @@ import tech.makers.aceplay.playlist.Playlist;
 import tech.makers.aceplay.track.Track;
 
 @Entity
-public class PlaylistTracks extends Serializable{
+public class PlaylistTracks implements Serializable {
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
@@ -31,9 +32,27 @@ public class PlaylistTracks extends Serializable{
   @Column(name = "date_added")
   private LocalDateTime dateAdded;
 
+  public PlaylistTracks() {}
+
   public PlaylistTracks(Playlist playlist, Track track) {
     this.playlist = playlist;
     this.track = track;
     this.dateAdded = LocalDateTime.now(Clock.systemUTC());
+  }
+
+  public Long getId() { 
+    return id;
+  }
+
+  public Playlist getPlaylist() {
+    return playlist;
+  }
+
+  public Track getTrack() {
+    return track;
+  }
+
+  public LocalDateTime getDateAdded() {
+    return dateAdded;
   }
 }

--- a/src/main/java/tech/makers/aceplay/playlisttracks/PlaylistTracks.java
+++ b/src/main/java/tech/makers/aceplay/playlisttracks/PlaylistTracks.java
@@ -1,0 +1,39 @@
+package tech.makers.aceplay.playlisttracks;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import tech.makers.aceplay.playlist.Playlist;
+import tech.makers.aceplay.track.Track;
+
+@Entity
+public class PlaylistTracks extends Serializable{
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+  
+  @ManyToOne
+  @JoinColumn(name = "playlist_id")
+  private Playlist playlist;
+
+  @ManyToOne
+  @JoinColumn(name = "track_id")
+  private Track track;
+
+  @Column(name = "date_added")
+  private LocalDateTime dateAdded;
+
+  public PlaylistTracks(Playlist playlist, Track track) {
+    this.playlist = playlist;
+    this.track = track;
+    this.dateAdded = LocalDateTime.now(Clock.systemUTC());
+  }
+}

--- a/src/main/java/tech/makers/aceplay/playlisttracks/PlaylistTracks.java
+++ b/src/main/java/tech/makers/aceplay/playlisttracks/PlaylistTracks.java
@@ -40,14 +40,6 @@ public class PlaylistTracks implements Serializable {
     this.dateAdded = LocalDateTime.now(Clock.systemUTC());
   }
 
-  public Long getId() { 
-    return id;
-  }
-
-  public Playlist getPlaylist() {
-    return playlist;
-  }
-
   public Track getTrack() {
     return track;
   }

--- a/src/main/java/tech/makers/aceplay/playlisttracks/PlaylistTracksRepository.java
+++ b/src/main/java/tech/makers/aceplay/playlisttracks/PlaylistTracksRepository.java
@@ -1,0 +1,5 @@
+package tech.makers.aceplay.playlisttracks;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface PlaylistTracksRepository extends CrudRepository<PlaylistTracks, Long> {}

--- a/src/main/java/tech/makers/aceplay/track/Track.java
+++ b/src/main/java/tech/makers/aceplay/track/Track.java
@@ -4,8 +4,13 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Set;
+
+import tech.makers.aceplay.playlisttracks.PlaylistTracks;
 
 // https://www.youtube.com/watch?v=5r3QU09v7ig&t=2999s
 @Entity
@@ -19,6 +24,9 @@ public class Track {
   private String artist;
 
   private URL publicUrl;
+
+  @OneToMany(mappedBy = "track")
+  private Set<PlaylistTracks> playlists;
 
   public Track() { }
 


### PR DESCRIPTION
When we add a track to a playlist, currently we don't record when the track was added to the playlist. We want to record the time the track was added to the playlist, and then order results when we get playlists such that the last track added appears at the bottom

This is achieved in this PR using the following technique:

- Split the Many-to-Many mapping of Playlist <> Tracks which uses a composite table into a One-to-Many-to-Many-to-One relationship which uses a primary key table (which also adds the date)
- This means instead of mapping Playlist <> Tracks directly, we map using an intermediary PlaylistTracks. So one Playlist maps to many PlaylistTracks, and many PlaylistTracks map to one Track. This is actually the same thing that's happening with the Many-to-Many relationship, the difference is we've taken control of the intermediary rather than it be automatic.
- Built a simple repository and entity for PlaylistTracks so that we can persist to that table manually
- By persisting to the PlaylistTracks table we implicitly add a track to a playlist. Rather than a playlist storing all of the tracks on it, it stores a list of PlaylistTracks which contain both the track and the date added. You can see how that looks in the JSON response here:

![Screenshot 2022-06-22 at 11 39 56](https://user-images.githubusercontent.com/9260297/175009859-2ef348d6-d6e5-4b06-b2ba-75b58714c3c5.png)


